### PR TITLE
bsd-user: port EXCP_YIELD handling from linux-user

### DIFF
--- a/bsd-user/aarch64/target_arch_cpu.h
+++ b/bsd-user/aarch64/target_arch_cpu.h
@@ -152,6 +152,9 @@ static inline void target_cpu_loop(CPUARMState *env)
             cpu_exec_step_atomic(cs);
             break;
 
+        case EXCP_YIELD:
+            /* nothing to do here for user-mode, just resume guest code */
+            break;
         default:
             fprintf(stderr, "qemu: unhandled CPU exception 0x%x - aborting\n",
                     trapnr);

--- a/bsd-user/arm/target_arch_cpu.h
+++ b/bsd-user/arm/target_arch_cpu.h
@@ -316,6 +316,9 @@ static inline void target_cpu_loop(CPUARMState *env)
         case EXCP_ATOMIC:
             cpu_exec_step_atomic(cs);
             break;
+        case EXCP_YIELD:
+            /* nothing to do here for user-mode, just resume guest code */
+            break;
         default:
             fprintf(stderr, "qemu: unhandled CPU exception 0x%x - aborting\n",
                     trapnr);


### PR DESCRIPTION
Taken from upstream f911e0a323f, for the exact same reasoning.

Reported-by: Steve Wills <swills@FreeBSD.org>
Signed-off-by: Kyle Evans <kevans@FreeBSD.org>