### PR TITLE
Re-organize maximum arg bits

### DIFF
--- a/bsd-user/freebsd/target_os_vmparam.h
+++ b/bsd-user/freebsd/target_os_vmparam.h
@@ -3,8 +3,6 @@
 
 #include "target_arch_vmparam.h"
 
-#define TARGET_ARG_MAX          262144
-
 /* Compare to sys/exec.h */
 struct target_ps_strings {
     abi_ulong ps_argvstr;

--- a/bsd-user/qemu.h
+++ b/bsd-user/qemu.h
@@ -136,11 +136,12 @@ extern const char *qemu_uname_release;
 
 /* ??? See if we can avoid exposing so much of the loader internals.  */
 /*
- * MAX_ARG_PAGES defines the number of pages allocated for arguments
- * and envelope for the new program. 64 should suffice, this gives
- * a maximum env+arg of 256kB w/4KB pages!
+ * TARGET_ARG_MAX defines the number of bytes allocated for arguments
+ * and envelope for the new program. 256k should suffice for a reasonable
+ * maxiumum env+arg.
  */
-#define MAX_ARG_PAGES 64
+#define TARGET_ARG_MAX (256 * 1024)
+#define MAX_ARG_PAGES (TARGET_ARG_MAX / TARGET_PAGE_SIZE)
 
 /*
  * This structure is used to hold the arguments that are

--- a/bsd-user/qemu.h
+++ b/bsd-user/qemu.h
@@ -138,9 +138,14 @@ extern const char *qemu_uname_release;
 /*
  * TARGET_ARG_MAX defines the number of bytes allocated for arguments
  * and envelope for the new program. 256k should suffice for a reasonable
- * maxiumum env+arg.
+ * maxiumum env+arg in 32-bit environments, bump it up to 512k for !ILP32
+ * platforms.
  */
+#if TARGET_ABI_BITS > 32
+#define TARGET_ARG_MAX (512 * 1024)
+#else
 #define TARGET_ARG_MAX (256 * 1024)
+#endif
 #define MAX_ARG_PAGES (TARGET_ARG_MAX / TARGET_PAGE_SIZE)
 
 /*


### PR DESCRIPTION
Drop the FreeBSD-specific TARGET_ARG_MAX; define it like that in bsd-user/qemu.h and derive MAX_ARG_PAGES. Increase it for !ILP32 to fix an issue observed by @swills