### PR TITLE
Catch up to recent syscalls

### DIFF
--- a/bsd-user/freebsd/syscall_nr.h
+++ b/bsd-user/freebsd/syscall_nr.h
@@ -488,7 +488,7 @@
 /* #define	TARGET_FREEBSD_NR_fhlinkat	566 */
 /* #define	TARGET_FREEBSD_NR_fhreadlink	567 */
 /* #define	TARGET_FREEBSD_NR_funlinkat	568 */
-/* #define	TARGET_FREEBSD_NR_copy_file_range	569 */
+#define	TARGET_FREEBSD_NR_copy_file_range	569
 #define	TARGET_FREEBSD_NR___sysctlbyname	570
 #define	TARGET_FREEBSD_NR_shm_open2	571
 #define	TARGET_FREEBSD_NR_shm_rename	572

--- a/bsd-user/freebsd/syscall_nr.h
+++ b/bsd-user/freebsd/syscall_nr.h
@@ -496,7 +496,7 @@
 #define	TARGET_FREEBSD_NR___realpathat	574
 #define	TARGET_FREEBSD_NR_close_range	575
 /* #define	TARGET_FREEBSD_NR_rpctls_syscall	576 */
-/* #define	TARGET_FREEBSD_NR___specialfd	577 */
+#define	TARGET_FREEBSD_NR___specialfd	577
 /* #define	TARGET_FREEBSD_NR_aio_writev	578 */
 /* #define	TARGET_FREEBSD_NR_aio_readv		579 */
 #define	TARGET_FREEBSD_NR_MAXSYSCALL	580

--- a/bsd-user/freebsd/syscall_nr.h
+++ b/bsd-user/freebsd/syscall_nr.h
@@ -484,11 +484,11 @@
 #define	TARGET_FREEBSD_NR_cpuset_setdomain	562
 #define	TARGET_FREEBSD_NR_getrandom	563
 #define	TARGET_FREEBSD_NR___sysctlbyname	570
-#define	TARGET_FREEBSD_NR_shm_open2     571
-#define	TARGET_FREEBSD_NR_shm_rename    572
-/* #define	TARGET_FREEBSD_NR_sigfastblock  573 */
-#define	TARGET_FREEBSD_NR___realpathat  574
-#define	TARGET_FREEBSD_NR_close_range   575
+#define	TARGET_FREEBSD_NR_shm_open2	571
+#define	TARGET_FREEBSD_NR_shm_rename	572
+/* #define	TARGET_FREEBSD_NR_sigfastblock	573 */
+#define	TARGET_FREEBSD_NR___realpathat	574
+#define	TARGET_FREEBSD_NR_close_range	575
 #define	TARGET_FREEBSD_NR_MAXSYSCALL	576
 /* Legacy system calls. */
 #ifndef	TARGET_FREEBSD_NR_killpg

--- a/bsd-user/freebsd/syscall_nr.h
+++ b/bsd-user/freebsd/syscall_nr.h
@@ -483,13 +483,23 @@
 #define	TARGET_FREEBSD_NR_cpuset_getdomain	561
 #define	TARGET_FREEBSD_NR_cpuset_setdomain	562
 #define	TARGET_FREEBSD_NR_getrandom	563
+/* #define	TARGET_FREEBSD_NR_getfhat	564 */
+/* #define	TARGET_FREEBSD_NR_fhlink	565 */
+/* #define	TARGET_FREEBSD_NR_fhlinkat	566 */
+/* #define	TARGET_FREEBSD_NR_fhreadlink	567 */
+/* #define	TARGET_FREEBSD_NR_funlinkat	568 */
+/* #define	TARGET_FREEBSD_NR_copy_file_range	569 */
 #define	TARGET_FREEBSD_NR___sysctlbyname	570
 #define	TARGET_FREEBSD_NR_shm_open2	571
 #define	TARGET_FREEBSD_NR_shm_rename	572
 /* #define	TARGET_FREEBSD_NR_sigfastblock	573 */
 #define	TARGET_FREEBSD_NR___realpathat	574
 #define	TARGET_FREEBSD_NR_close_range	575
-#define	TARGET_FREEBSD_NR_MAXSYSCALL	576
+/* #define	TARGET_FREEBSD_NR_rpctls_syscall	576 */
+/* #define	TARGET_FREEBSD_NR___specialfd	577 */
+/* #define	TARGET_FREEBSD_NR_aio_writev	578 */
+/* #define	TARGET_FREEBSD_NR_aio_readv		579 */
+#define	TARGET_FREEBSD_NR_MAXSYSCALL	580
 /* Legacy system calls. */
 #ifndef	TARGET_FREEBSD_NR_killpg
 #define	TARGET_FREEBSD_NR_killpg	146

--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -110,6 +110,11 @@ safe_syscall6(ssize_t, sendto, int, fd, const void *, buf, size_t, len, int,
 safe_syscall3(ssize_t, recvmsg, int, s, struct msghdr *, msg, int, flags);
 safe_syscall3(ssize_t, sendmsg, int, s, const struct msghdr *, msg, int, flags);
 
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1300133
+safe_syscall6(ssize_t, copy_file_range, int, infd, off_t *, inoffp, int, outfd,
+    off_t *, outoffp, size_t, len, unsigned int, flags);
+#endif
+
 int g_posix_timers[32] = { 0, } ;
 
 /*
@@ -882,6 +887,12 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
     case TARGET_FREEBSD_NR___realpathat:
         /* __realpathat(2) (XXX no realpathat()) */
         ret = do_freebsd_realpathat(arg1, arg2, arg3, arg4, arg5);
+        break;
+#endif
+
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1300037
+    case TARGET_FREEBSD_NR_copy_file_range:
+        ret = do_freebsd_copy_file_range(arg1, arg2, arg3, arg4, arg5, arg6);
         break;
 #endif
 

--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -896,6 +896,12 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
         break;
 #endif
 
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1300133
+    case TARGET_FREEBSD_NR___specialfd:
+        ret = do_freebsd___specialfd(arg1, arg2, arg3);
+        break;
+#endif
+
         /*
          * stat system calls
          */

--- a/bsd-user/syscall_defs.h
+++ b/bsd-user/syscall_defs.h
@@ -714,6 +714,16 @@ struct target_freebsd_flock {
 /* user: vfork(2) semantics, clear signals */
 #define	TARGET_RFSPAWN		(1U<<31)
 
+/* sys/specialfd.h */
+enum target_specialfd_type {
+    TARGET_SPECIALFD_EVENT         = 1,
+};
+
+struct target_specialfd_eventfd {
+    unsigned int initval;
+    int flags;
+};
+
 /*
  * FreeBSD thread and user mutex support.
  */


### PR DESCRIPTION
Add in unimplemented syscalls commented out as a reminder of what the gaps consist of, implement copy_file_range(2) and __specialfd(2) as they are both either used in the base system or used in ports building (__specialfd backs eventfd).