### PR TITLE
bsd-user: patch _umtx_op through to the kernel

### DIFF
--- a/bsd-user/qemu.h
+++ b/bsd-user/qemu.h
@@ -364,7 +364,7 @@ abi_long freebsd_umtx_sem2_wake(abi_ulong obj);
 abi_long freebsd_umtx_sem_wait(abi_ulong obj, size_t tsz, void *t);
 abi_long freebsd_umtx_sem_wake(abi_ulong obj);
 abi_long freebsd_lock_umutex(abi_ulong target_addr, uint32_t id,
-        void *ts, size_t tsz, int mode);
+        void *ts, size_t tsz, int mode, abi_ulong val);
 abi_long freebsd_unlock_umutex(abi_ulong target_addr, uint32_t id);
 abi_long freebsd_cv_wait(abi_ulong target_ucond_addr,
                 abi_ulong target_umtx_addr, struct timespec *ts, int wflags);


### PR DESCRIPTION
Recent stable/12, all of stable/13 and later support setting special
bits to indicate that the kernel should provide 32bit compat for any
given op supplied to _umtx_op.

This patch takes advantage of that work to reduce the amount of hangs
we typically see during builds. The former emulation of these ops must
still be present in some sense for cross-endian emulation, but the
number of platforms that this effects is somewhat minimal given that
ppc* packages are built natively rather than emulated -- thus removing
some of the urgency.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>