### PR TITLE
bsd-user: freebsd: suppress CIOCGSESSION

### DIFF
--- a/bsd-user/freebsd/os-ioctl-cmds.h
+++ b/bsd-user/freebsd/os-ioctl-cmds.h
@@ -48,6 +48,9 @@ IOCTL(FIONSPACE, IOC_R, MK_PTR(TYPE_INT))
 IOCTL(FIOSEEKDATA, IOC_RW, MK_PTR(TYPE_ULONG))
 IOCTL(FIOSEEKHOLE, IOC_RW, MK_PTR(TYPE_ULONG))
 
+/* crypto/cryptodev.h */
+IOCTL_SPECIAL(CIOCGSESSION, IOC_RW, do_ioctl_unsupported, TYPE_INT)
+
 /* netinet6/in6_var.h */
 IOCTL_SPECIAL(SIOCGIFAFLAG_IN6, IOC_RW, do_ioctl_in6_ifreq_sockaddr_int, MK_PTR(MK_STRUCT(STRUCT_in6_ifreq_int)))
 IOCTL_SPECIAL(SIOCGIFALIFETIME_IN6, IOC_RW, do_ioctl_in6_ifreq_sockaddr_int, MK_PTR(MK_STRUCT(STRUCT_in6_ifreq_int)))


### PR DESCRIPTION
OpenSSL may try to use /dev/crypto, which is not really supported under
qemu-user-static.  Currently, it emits tons of errors about the ioctl
being unsupported when we're just returning ENOSYS anyways.

"Implement" CIOCGSESSION with do_ioctl_unsupported, which will instead
quietly return ENXIO. This ioctl is theoretically niche enough that we
can assume callers will handle the error correctly without us needing
to see a warning.

This was noted by Netgate.

CC @rbgarga, @markjdb 