### PR TITLE
Revert CRIOGET removal

### DIFF
--- a/bsd-user/bsd-ioctl.c
+++ b/bsd-user/bsd-ioctl.c
@@ -346,6 +346,8 @@ static IOCTLEntry ioctl_entries[] = {
     { TARGET_ ## cmd, cmd, #cmd, access, 0, { __VA_ARGS__ } },
 #define IOCTL_SPECIAL(cmd, access, dofn, ...) \
     { TARGET_ ## cmd, cmd, #cmd, access, dofn, { __VA_ARGS__ } },
+#define IOCTL_SPECIAL_UNIMPL(cmd, access, dofn, ...) \
+    { TARGET_ ## cmd, 0, #cmd, access, dofn, { __VA_ARGS__ } },
 #include "os-ioctl-cmds.h"
     { 0, 0 },
 };

--- a/bsd-user/freebsd/os-ioctl-cmds.h
+++ b/bsd-user/freebsd/os-ioctl-cmds.h
@@ -50,6 +50,7 @@ IOCTL(FIOSEEKHOLE, IOC_RW, MK_PTR(TYPE_ULONG))
 
 /* crypto/cryptodev.h */
 IOCTL_SPECIAL(CIOCGSESSION, IOC_RW, do_ioctl_unsupported, TYPE_INT)
+IOCTL_SPECIAL_UNIMPL(CRIOGET, IOC_RW, do_ioctl_unsupported, TYPE_INT)
 
 /* netinet6/in6_var.h */
 IOCTL_SPECIAL(SIOCGIFAFLAG_IN6, IOC_RW, do_ioctl_in6_ifreq_sockaddr_int, MK_PTR(MK_STRUCT(STRUCT_in6_ifreq_int)))

--- a/bsd-user/freebsd/os-ioctl-cryptodev.h
+++ b/bsd-user/freebsd/os-ioctl-cryptodev.h
@@ -69,6 +69,7 @@ struct target_crypt_kop {
         struct target_crparam	crk_param[TARGET_CRK_MAXPARAM];
 };
 
+#define	TARGET_CRIOGET		TARGET_IOWR('c', 100, u_int32_t)
 #define TARGET_CRIOASYMFEAT	TARGET_CIOCASYMFEAT
 #define	TARGET_CRIOFINDDEV	TARGET_CIOCFINDDEV
 

--- a/bsd-user/freebsd/os-sys.c
+++ b/bsd-user/freebsd/os-sys.c
@@ -333,9 +333,9 @@ host_to_target_kinfo_file(struct target_kinfo_file *tkif,
 
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 900000
     switch(type) {
-    case KF_TYPE_FIFO:
-    case KF_TYPE_SHM:
-    case KF_TYPE_VNODE:
+    case TARGET_KF_TYPE_FIFO:
+    case TARGET_KF_TYPE_SHM:
+    case TARGET_KF_TYPE_VNODE:
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1200031
         __put_user(hkif->kf_un.kf_file.kf_file_type,
                 &tkif->kf_un.kf_file.kf_file_type);
@@ -366,7 +366,7 @@ host_to_target_kinfo_file(struct target_kinfo_file *tkif,
                 &tkif->kf_un.kf_file.kf_file_mode);
         break;
 
-    case KF_TYPE_SOCKET:
+    case TARGET_KF_TYPE_SOCKET:
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1200031
         __put_user(hkif->kf_un.kf_sock.kf_sock_domain0,
                 &tkif->kf_un.kf_sock.kf_sock_domain0);
@@ -395,7 +395,7 @@ host_to_target_kinfo_file(struct target_kinfo_file *tkif,
                 &tkif->kf_un.kf_sock.kf_sock_rcv_sb_state);
         break;
 
-    case KF_TYPE_PIPE:
+    case TARGET_KF_TYPE_PIPE:
         __put_user(hkif->kf_un.kf_pipe.kf_pipe_addr,
                 &tkif->kf_un.kf_pipe.kf_pipe_addr);
         __put_user(hkif->kf_un.kf_pipe.kf_pipe_peer,
@@ -404,14 +404,14 @@ host_to_target_kinfo_file(struct target_kinfo_file *tkif,
                 &tkif->kf_un.kf_pipe.kf_pipe_buffer_cnt);
         break;
 
-    case KF_TYPE_SEM:
+    case TARGET_KF_TYPE_SEM:
         __put_user(hkif->kf_un.kf_sem.kf_sem_value,
                 &tkif->kf_un.kf_sem.kf_sem_value);
         __put_user(hkif->kf_un.kf_sem.kf_sem_mode,
                 &tkif->kf_un.kf_sem.kf_sem_mode);
         break;
 
-    case KF_TYPE_PTS:
+    case TARGET_KF_TYPE_PTS:
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1200031
         __put_user(hkif->kf_un.kf_pts.kf_pts_dev_freebsd11,
                 &tkif->kf_un.kf_pts.kf_pts_dev_freebsd11);
@@ -423,16 +423,16 @@ host_to_target_kinfo_file(struct target_kinfo_file *tkif,
 #endif
         break;
 
-    case KF_TYPE_PROCDESC:
+    case TARGET_KF_TYPE_PROCDESC:
         __put_user(hkif->kf_un.kf_proc.kf_pid,
                 &tkif->kf_un.kf_proc.kf_pid);
         break;
 
 
-    case KF_TYPE_KQUEUE:
-    case KF_TYPE_MQUEUE:
-    case KF_TYPE_NONE:
-    case KF_TYPE_UNKNOWN:
+    case TARGET_KF_TYPE_KQUEUE:
+    case TARGET_KF_TYPE_MQUEUE:
+    case TARGET_KF_TYPE_NONE:
+    case TARGET_KF_TYPE_UNKNOWN:
     default:
         /* Do nothing. */
         break;

--- a/bsd-user/freebsd/os-sys.c
+++ b/bsd-user/freebsd/os-sys.c
@@ -429,6 +429,7 @@ host_to_target_kinfo_file(struct target_kinfo_file *tkif,
         break;
 
 
+    case TARGET_KF_TYPE_CRYPTO:
     case TARGET_KF_TYPE_KQUEUE:
     case TARGET_KF_TYPE_MQUEUE:
     case TARGET_KF_TYPE_NONE:

--- a/bsd-user/freebsd/target_os_user.h
+++ b/bsd-user/freebsd/target_os_user.h
@@ -82,6 +82,21 @@ struct target_sockaddr_storage {
 #define TARGET_LOGNAMELEN           17
 #define TARGET_LOGINCLASSLEN        17
 
+#define	TARGET_KF_TYPE_NONE	0
+#define	TARGET_KF_TYPE_VNODE	1
+#define	TARGET_KF_TYPE_SOCKET	2
+#define	TARGET_KF_TYPE_PIPE	3
+#define	TARGET_KF_TYPE_FIFO	4
+#define	TARGET_KF_TYPE_KQUEUE	5
+#define	TARGET_KF_TYPE_CRYPTO	6
+#define	TARGET_KF_TYPE_MQUEUE	7
+#define	TARGET_KF_TYPE_SHM	8
+#define	TARGET_KF_TYPE_SEM	9
+#define	TARGET_KF_TYPE_PTS	10
+#define	TARGET_KF_TYPE_PROCDESC	11
+#define	TARGET_KF_TYPE_DEV	12
+#define	TARGET_KF_TYPE_UNKNOWN	255
+
 struct target_kinfo_proc {
     int32_t     ki_structsize;      /* size of this structure */
     int32_t     ki_layout;          /* reserved: layout identifier */


### PR DESCRIPTION
Adds a 0-host cmd mapper for unimplemented ioctls so we can return a proper error or shim it to what it should be. Future work may simply merge IOCTL_SPECIAL with IOCTL_SPECIAL_UNIMPL, but a little more consideration needs to be put into whether host_cmd really matters or not for special handlers.