### PR TITLE
Fix arguments to copy_file_range when off_t pointers are NULL.

### DIFF
--- a/bsd-user/freebsd/os-file.h
+++ b/bsd-user/freebsd/os-file.h
@@ -196,7 +196,7 @@ static inline abi_long do_freebsd_copy_file_range(int infd,
         outp = &outoff;
     }
 
-    ret = get_errno(safe_copy_file_range(infd, &inoff, outfd, &outoff, len,
+    ret = get_errno(safe_copy_file_range(infd, inp, outfd, outp, len,
         flags));
 
     if (inofftp != 0)


### PR DESCRIPTION
Obvious fix; the old version breaks when cross-building ruby, which uses copy_file_range with null offsets to copy file content when installing itself.