### PR TITLE
Fixes against blitz-next

### DIFF
--- a/bsd-user/elfload.c
+++ b/bsd-user/elfload.c
@@ -2053,7 +2053,7 @@ static int elf_core_dump(int signr, CPUArchState *env)
      *
      * See kern/imgact_elf.c  __elfN(corehdr)().
      */
-    fill_elf_header(&elf, segs + 1, ELF_MACHINE, 0);
+    fill_elf_header(&elf, segs + 1, ELF_MACHINE, ts->info->elf_flags);
     if (dump_write(fd, &elf, sizeof (elf)) != 0)
         goto out;
 

--- a/bsd-user/elfload.c
+++ b/bsd-user/elfload.c
@@ -777,6 +777,8 @@ int load_elf_binary(struct bsd_binprm *bprm, struct target_pt_regs *regs,
     setup_arg_pages(bprm, info, &bprm->p, &bprm->stringp);
     info->start_stack = bprm->p;
 
+    info->elf_flags = elf_ex.e_flags;
+
     error = load_elf_sections(&elf_ex, elf_phdata, bprm->fd, et_dyn_addr,
         &load_addr);
     for (i = 0, elf_ppnt = elf_phdata; i < elf_ex.e_phnum; i++, elf_ppnt++) {

--- a/bsd-user/freebsd/os-misc.h
+++ b/bsd-user/freebsd/os-misc.h
@@ -646,7 +646,7 @@ static inline abi_long do_freebsd_shm_rename(abi_ulong fromptr, abi_ulong toptr,
 }
 #endif /* __FreeBSD_version >= 1300049 */
 
-#if defined(HAVE_GETRANDOM)
+#if defined(CONFIG_GETRANDOM)
 static inline abi_long do_freebsd_getrandom(abi_ulong buf, abi_ulong buflen,
         abi_ulong flags)
 {

--- a/bsd-user/freebsd/os-sys.c
+++ b/bsd-user/freebsd/os-sys.c
@@ -1139,12 +1139,12 @@ static abi_long do_freebsd_sysctl_oid(CPUArchState *env, int32_t *snamep,
 
     /* Handle some arch/emulator dependent sysctl()'s here. */
     switch (snamep[0]) {
-#if defined(TARGET_PPC)
+#if defined(TARGET_PPC) || defined(TARGET_PPC64)
     case CTL_MACHDEP:
         switch (snamep[1]) {
-        case 1:    /* This should be documented elsewhere. */
-            holdlen = sizeof(abi_ulong);
-            (*(abi_ulong *)holdp) = tswapal(env->dcache_line_size);
+        case 1:    /* CPU_CACHELINE */
+            holdlen = sizeof(uint32_t);
+            (*(uint32_t *)holdp) = tswap32(env->dcache_line_size);
             ret = 0;
             goto out;
         }

--- a/bsd-user/freebsd/target_os_user.h
+++ b/bsd-user/freebsd/target_os_user.h
@@ -402,7 +402,8 @@ struct target_kinfo_vmentry {
 	uint16_t kve_vn_mode;			/* File mode. */
 	uint16_t kve_status;			/* Status flags. */
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1200031
-#if __FreeBSD_version >= 1400009
+#if (__FreeBSD_version >= 1300501 && __FreeBSD_version < 1400000) || \
+    __FreeBSD_version >= 1400009
 	union {
 		uint64_t _kve_vn_fsid;		/* dev_t of vnode location */
 		uint64_t _kve_obj;		/* handle of anon obj */

--- a/bsd-user/ppc/target_arch.h
+++ b/bsd-user/ppc/target_arch.h
@@ -4,4 +4,7 @@
 
 #include "qemu.h"
 
+/* target_arch_cpu.c */
+extern bool bsd_ppc_is_elfv1(CPUPPCState *env);
+
 #endif /* !_TARGET_ARCH_H_ */

--- a/bsd-user/ppc/target_arch_cpu.c
+++ b/bsd-user/ppc/target_arch_cpu.c
@@ -65,3 +65,16 @@ int ppc_dcr_write (ppc_dcr_t *dcr_env, int dcrn, uint32_t val)
 {
     return -1;
 }
+
+bool bsd_ppc_is_elfv1(CPUPPCState *env)
+{
+#if defined(TARGET_PPC64)
+    CPUState *cpu = env_cpu(env);
+    struct TaskState *ts = (struct TaskState *)cpu->opaque;
+    struct image_info *infop = ts->info;
+
+    return ((infop->elf_flags & 0x3) < 2);
+#else
+    return 0;
+#endif
+}

--- a/bsd-user/ppc/target_arch_cpu.h
+++ b/bsd-user/ppc/target_arch_cpu.h
@@ -22,7 +22,12 @@
 #include "target_arch.h"
 
 #if defined(TARGET_PPC64) && !defined(TARGET_ABI32)
+#if defined(TARGET_WORDS_BIGENDIAN)
 #define TARGET_DEFAULT_CPU_MODEL "ppc64"
+#else
+/* LE is restricted to POWER8 and up. */
+#define TARGET_DEFAULT_CPU_MODEL "power8"
+#endif
 #else
 #define TARGET_DEFAULT_CPU_MODEL "ppc"
 #endif

--- a/bsd-user/ppc/target_arch_sigtramp.h
+++ b/bsd-user/ppc/target_arch_sigtramp.h
@@ -9,18 +9,21 @@ static inline abi_long setup_sigtramp(abi_ulong offset, unsigned sigf_uc,
     int i;
 #if defined(TARGET_PPC64) && !defined(TARGET_ABI32)
     uint32_t sigtramp_code[TARGET_SZSIGCODE/TARGET_INSN_SIZE] = {
-    /*  1 */ 0x3821FF90,   /* addi r1,r1,-112 */
-    /*  2 */ 0x7C4802A6,   /* mflr r2 */
-    /*  3 */ 0xE8020000,   /* ld r0,0(r2) */
-    /*  4 */ 0xE8420008,   /* ld r2,8(r2) */
-    /*  5 */ 0x7C0803A6,   /* mtlr r0 */
-    /*  6 */ 0x4E800021,   /* blrl */
-    /*  7 */ 0x38610070 + sigf_uc,   /* addi r3,r1,112+SF_UC */
-    /*  8 */ 0x38000000 + sys_sigreturn, /* li r0,SYS_sigreturn */
-    /*  9 */ 0x44000002,   /* sc */
-    /* 10 */ 0x38000001,   /* li r0,SYS_exit */
-    /* 11 */ 0x44000002,   /* sc */
-    /* 12 */ 0x60000000    /* nop */
+    /* ELFv1 entry point */
+    /*  1 */ 0x7C4802A6,   /* mflr r2 */
+    /*  2 */ 0xE8020000,   /* ld r0,0(r2) */
+    /*  3 */ 0xE8420008,   /* ld r2,8(r2) */
+    /*  4 */ 0x7C0803A6,   /* mtlr r0 */
+    /* ELFv2 entry point */
+    /*  5 */ 0x3821FF90,   /* addi r1,r1,-112 */
+    /* Needed for ELFv2 ABI compliance */
+    /*  6 */ 0x7D8802A6,   /* mflr r12 */
+    /*  7 */ 0x4E800021,   /* blrl */
+    /*  8 */ 0x38610070 + sigf_uc,   /* addi r3,r1,112+SF_UC */
+    /*  9 */ 0x38000000 + sys_sigreturn, /* li r0,SYS_sigreturn */
+    /* 10 */ 0x44000002,   /* sc */
+    /* 11 */ 0x38000001,   /* li r0,SYS_exit */
+    /* 12 */ 0x44000002    /* sc */
     };
 #else
     uint32_t sigtramp_code[TARGET_SZSIGCODE/TARGET_INSN_SIZE] = {

--- a/bsd-user/ppc/target_arch_thread.h
+++ b/bsd-user/ppc/target_arch_thread.h
@@ -30,7 +30,7 @@ static inline void target_thread_set_upcall(CPUPPCState *regs, abi_ulong entry,
      * powerpc/include/param.h (STACKLIGN() macro)
      */
 #if defined(TARGET_PPC64) && !defined(TARGET_ABI32)
-    sp = ((u_int)(stack_base + stack_size) - 48) & ~0x1f;
+    sp = ((abi_ulong)(stack_base + stack_size) - 48) & ~0x1f;
 #else
     sp = ((u_int)(stack_base + stack_size) - 8) & ~0x1f;
 #endif

--- a/bsd-user/qemu.h
+++ b/bsd-user/qemu.h
@@ -84,6 +84,7 @@ struct image_info {
     abi_ulong data_offset;
     abi_ulong arg_start;
     abi_ulong arg_end;
+    uint32_t  elf_flags;
 };
 
 #define MAX_SIGQUEUE_SIZE 1024

--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -1855,7 +1855,7 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
         ret = do_obreak(arg1);
         break;
 
-#if defined(HAVE_GETRANDOM)
+#if defined(CONFIG_GETRANDOM)
     case TARGET_FREEBSD_NR_getrandom:
         ret = do_freebsd_getrandom(arg1, arg2, arg3);
         break;

--- a/default-configs/targets/ppc64le-bsd-user.mak
+++ b/default-configs/targets/ppc64le-bsd-user.mak
@@ -1,0 +1,4 @@
+TARGET_ARCH=ppc64
+TARGET_BASE_ARCH=ppc
+TARGET_ABI_DIR=ppc
+TARGET_XML_FILES= gdb-xml/power64-core.xml gdb-xml/power-fpu.xml gdb-xml/power-altivec.xml gdb-xml/power-spe.xml gdb-xml/power-vsx.xml


### PR DESCRIPTION
* Add ppc64le-bsd-user target.
* Fix ELFv2 loading for powerpc64* (needed for FreeBSD 13 and up binaries.)
* Set the default cpu model for ppc64le-bsd-user to POWER8.
* Fix build for stable/13.
* (More fixes, need to re-enumerate.)