### PR TITLE
Update for MFC'd close_range support in FreeBSD 12

### DIFF
--- a/bsd-user/freebsd/os-file.h
+++ b/bsd-user/freebsd/os-file.h
@@ -160,7 +160,7 @@ static inline abi_long do_bsd_chflagsat(__unused int fd,
 
 #endif /* !  __FreeBSD_version >= 1000000 */
 
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 1300091
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1201522
 /* close_range(2) */
 static inline abi_long do_freebsd_close_range(unsigned int lowfd,
     unsigned int highfd, int flags)
@@ -169,7 +169,7 @@ static inline abi_long do_freebsd_close_range(unsigned int lowfd,
     return (close_range(lowfd, highfd, flags));
 }
 
-#endif /* __FreeBSD_version >= 1300091 */
+#endif /* __FreeBSD_version >= 1201522 */
 
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1300037
 ssize_t safe_copy_file_range(int, off_t *, int, off_t *, size_t, unsigned int);

--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -632,7 +632,7 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
         ret = do_bsd_closefrom(arg1);
         break;
 
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 1300091
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1201522
     case TARGET_FREEBSD_NR_close_range: /* close_range(2) */
         ret = do_freebsd_close_range(arg1, arg2, arg3);
         break;


### PR DESCRIPTION
I was seeing "qemu: unsupported syscall: 575" within an ARMv7 poudriere build of py38-lxml (manifesting as "Please make sure the libxml2 and libxslt development packages are installed." due to xml2-config "crashing" the configure stage).  Eventually, I've tracked it down to the fact that close_range() support (syscall 575) was MFC'd in August 2020 (see https://github.com/freebsd/freebsd-src/commit/a80adba) but hadn't been exposed in qemu.

This patch simply expands the existing qemu support to cover the FreeBSD version mentioned in the MFC (1201522). 

Tested by applying against the FreeBSD-port emulators/qemu-user-static, deploying, and then rebuilding devel/py-lxml using an ARMv7 (git+https 2430d82b40e) poudriere jail.