### PR TITLE
bsd-user: Don't truncate the return value from freebsd_syscall

### DIFF
--- a/bsd-user/freebsd/os-syscall.c
+++ b/bsd-user/freebsd/os-syscall.c
@@ -1898,7 +1898,7 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
                             abi_long arg8)
 {
     CPUState *cpu = env_cpu(cpu_env);
-    int ret;
+    abi_long ret;
 
     trace_guest_user_syscall(cpu, num, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     if (do_strace) {


### PR DESCRIPTION
This was being assigned into an int variable which causes problems for 64bit targets. Fixes #40.

Signed-off-by: Doug Rabson <dfr@rabson.org>