### PR TITLE
Blitz

### DIFF
--- a/bsd-user/bsd-mem.c
+++ b/bsd-user/bsd-mem.c
@@ -31,8 +31,8 @@ void target_set_brk(abi_ulong new_brk)
     initial_target_brk = target_brk;
 }
 
-void target_to_host_ipc_perm__locked(struct ipc_perm *host_ip,
-                                     struct target_ipc_perm *target_ip)
+void target_to_host_ipc_perm(struct ipc_perm *host_ip,
+                             struct target_ipc_perm *target_ip)
 {
     __get_user(host_ip->cuid, &target_ip->cuid);
     __get_user(host_ip->cgid, &target_ip->cgid);
@@ -43,18 +43,10 @@ void target_to_host_ipc_perm__locked(struct ipc_perm *host_ip,
     __get_user(host_ip->key,  &target_ip->key);
 }
 
-abi_long target_to_host_shmid_ds(struct shmid_ds *host_sd,
-                                 abi_ulong target_addr)
+void target_to_host_shmid_ds(struct shmid_ds *host_sd,
+                             struct target_shmid_ds *target_sd)
 {
-    struct target_shmid_ds *target_sd;
-
-    if (!lock_user_struct(VERIFY_READ, target_sd, target_addr, 1)) {
-        return -TARGET_EFAULT;
-    }
-
-    target_to_host_ipc_perm__locked(&(host_sd->shm_perm),
-                                    &(target_sd->shm_perm));
-
+    target_to_host_ipc_perm(&host_sd->shm_perm, &target_sd->shm_perm);
     __get_user(host_sd->shm_segsz,  &target_sd->shm_segsz);
     __get_user(host_sd->shm_lpid,   &target_sd->shm_lpid);
     __get_user(host_sd->shm_cpid,   &target_sd->shm_cpid);
@@ -62,13 +54,10 @@ abi_long target_to_host_shmid_ds(struct shmid_ds *host_sd,
     __get_user(host_sd->shm_atime,  &target_sd->shm_atime);
     __get_user(host_sd->shm_dtime,  &target_sd->shm_dtime);
     __get_user(host_sd->shm_ctime,  &target_sd->shm_ctime);
-    unlock_user_struct(target_sd, target_addr, 0);
-
-    return 0;
 }
 
-void host_to_target_ipc_perm__locked(struct target_ipc_perm *target_ip,
-                                     struct ipc_perm *host_ip)
+void host_to_target_ipc_perm(struct target_ipc_perm *target_ip,
+                             struct ipc_perm *host_ip)
 {
     __put_user(host_ip->cuid, &target_ip->cuid);
     __put_user(host_ip->cgid, &target_ip->cgid);
@@ -79,18 +68,10 @@ void host_to_target_ipc_perm__locked(struct target_ipc_perm *target_ip,
     __put_user(host_ip->key,  &target_ip->key);
 }
 
-abi_long host_to_target_shmid_ds(abi_ulong target_addr,
-                                 struct shmid_ds *host_sd)
+void host_to_target_shmid_ds(struct target_shmid_ds *target_sd,
+                             struct shmid_ds *host_sd)
 {
-    struct target_shmid_ds *target_sd;
-
-    if (!lock_user_struct(VERIFY_WRITE, target_sd, target_addr, 0)) {
-        return -TARGET_EFAULT;
-    }
-
-    host_to_target_ipc_perm__locked(&(target_sd->shm_perm),
-                                    &(host_sd->shm_perm));
-
+    host_to_target_ipc_perm(&target_sd->shm_perm, &host_sd->shm_perm);
     __put_user(host_sd->shm_segsz,  &target_sd->shm_segsz);
     __put_user(host_sd->shm_lpid,   &target_sd->shm_lpid);
     __put_user(host_sd->shm_cpid,   &target_sd->shm_cpid);
@@ -98,7 +79,4 @@ abi_long host_to_target_shmid_ds(abi_ulong target_addr,
     __put_user(host_sd->shm_atime,  &target_sd->shm_atime);
     __put_user(host_sd->shm_dtime,  &target_sd->shm_dtime);
     __put_user(host_sd->shm_ctime,  &target_sd->shm_ctime);
-    unlock_user_struct(target_sd, target_addr, 1);
-
-    return 0;
 }

--- a/bsd-user/bsd-misc.c
+++ b/bsd-user/bsd-misc.c
@@ -31,192 +31,101 @@
 /*
  * BSD uuidgen(2) struct uuid conversion
  */
-abi_long host_to_target_uuid(abi_ulong target_addr, struct uuid *host_uuid)
+void host_to_target_uuid(struct target_uuid *target_uuid,
+                         struct uuid *host_uuid)
 {
-    struct target_uuid *target_uuid;
-
-    if (!lock_user_struct(VERIFY_WRITE, target_uuid, target_addr, 0)) {
-        return -TARGET_EFAULT;
-    }
     __put_user(host_uuid->time_low, &target_uuid->time_low);
     __put_user(host_uuid->time_mid, &target_uuid->time_mid);
     __put_user(host_uuid->time_hi_and_version,
-        &target_uuid->time_hi_and_version);
+               &target_uuid->time_hi_and_version);
     host_uuid->clock_seq_hi_and_reserved =
         target_uuid->clock_seq_hi_and_reserved;
     host_uuid->clock_seq_low = target_uuid->clock_seq_low;
     memcpy(host_uuid->node, target_uuid->node, TARGET_UUID_NODE_LEN);
-    unlock_user_struct(target_uuid, target_addr, 1);
-    return 0;
 }
 
-abi_long target_to_host_semarray(int semid, unsigned short **host_array,
-        abi_ulong target_addr)
+void target_to_host_semarray(unsigned short *host_array,
+                             unsigned short *target_array,
+                             int nsems)
 {
-    abi_long ret;
-    int nsems, i;
-    unsigned short *array;
-    union semun semun;
-    struct semid_ds semid_ds;
-
-    semun.buf = &semid_ds;
-    ret = semctl(semid, 0, IPC_STAT, semun);
-    if (ret == -1) {
-        return get_errno(ret);
+    for (int i = 0; i < nsems; i++) {
+        __get_user(host_array[i], &target_array[i]);
     }
-    nsems = semid_ds.sem_nsems;
-    *host_array = (unsigned short *)malloc(nsems * sizeof(unsigned short));
-    array = lock_user(VERIFY_READ, target_addr,
-        nsems * sizeof(unsigned short), 1);
-    if (array == NULL) {
-        free(*host_array);
-        return -TARGET_EFAULT;
-    }
-    for (i = 0; i < nsems; i++) {
-        (*host_array)[i] = array[i];
-    }
-    unlock_user(array, target_addr, 0);
-
-    return 0;
 }
 
-abi_long host_to_target_semarray(int semid, abi_ulong target_addr,
-        unsigned short **host_array)
+void host_to_target_semarray(unsigned short *target_array,
+                             unsigned short *host_array,
+                             int nsems)
 {
-    abi_long ret;
-    int nsems, i;
-    unsigned short *array;
-    union semun semun;
-    struct semid_ds semid_ds;
-
-    semun.buf = &semid_ds;
-
-    ret = semctl(semid, 0, IPC_STAT, semun);
-    if (ret == -1) {
-        free(*host_array);
-        return get_errno(ret);
+    for (int i = 0; i < nsems; i++) {
+        __put_user(host_array[i], &target_array[i]);
     }
-
-    nsems = semid_ds.sem_nsems;
-    array = (unsigned short *)lock_user(VERIFY_WRITE, target_addr,
-        nsems * sizeof(unsigned short), 0);
-    if (array == NULL) {
-        free(*host_array);
-        return -TARGET_EFAULT;
-    }
-    for (i = 0; i < nsems; i++) {
-        array[i] = (*host_array)[i];
-    }
-    free(*host_array);
-    unlock_user(array, target_addr, 1);
-    return 0;
 }
 
-abi_long target_to_host_semid_ds(struct semid_ds *host_sd,
-        abi_ulong target_addr)
+void target_to_host_semid_ds(struct semid_ds *host_sd,
+                             struct target_semid_ds *target_sd)
 {
-    struct target_semid_ds *target_sd;
-
-    if (!lock_user_struct(VERIFY_READ, target_sd, target_addr, 1)) {
-        return -TARGET_EFAULT;
-    }
-    target_to_host_ipc_perm__locked(&(host_sd->sem_perm), &target_sd->sem_perm);
+    target_to_host_ipc_perm(&host_sd->sem_perm, &target_sd->sem_perm);
     /* sem_base is not used by kernel for IPC_STAT/IPC_SET */
     /* host_sd->sem_base  = g2h_untagged(target_sd->sem_base); */
-    host_sd->sem_nsems = tswap16(target_sd->sem_nsems);
-#if defined(TARGET_I386)
-    host_sd->sem_otime = tswap32(target_sd->sem_otime);
-    host_sd->sem_ctime = tswap32(target_sd->sem_ctime);
-#else
-    host_sd->sem_otime = tswap64(target_sd->sem_otime);
-    host_sd->sem_ctime = tswap64(target_sd->sem_ctime);
-#endif
-    unlock_user_struct(target_sd, target_addr, 0);
-    return 0;
+    __get_user(host_sd->sem_nsems, &target_sd->sem_nsems);
+    __get_user(host_sd->sem_otime, &target_sd->sem_otime);
+    __get_user(host_sd->sem_ctime, &target_sd->sem_ctime);
 }
 
-abi_long host_to_target_semid_ds(abi_ulong target_addr,
-        struct semid_ds *host_sd)
+void host_to_target_semid_ds(struct target_semid_ds *target_sd,
+                             struct semid_ds *host_sd)
 {
-    struct target_semid_ds *target_sd;
-
-    if (!lock_user_struct(VERIFY_WRITE, target_sd, target_addr, 0)) {
-        return -TARGET_EFAULT;
-    }
-    host_to_target_ipc_perm__locked(&target_sd->sem_perm,
-	&host_sd->sem_perm);
+    host_to_target_ipc_perm(&target_sd->sem_perm, &host_sd->sem_perm);
     /* sem_base is not used by kernel for IPC_STAT/IPC_SET */
     /* target_sd->sem_base = h2g((void *)host_sd->sem_base); */
-    target_sd->sem_nsems = tswap16(host_sd->sem_nsems);
-    target_sd->sem_otime = tswapal(host_sd->sem_otime);
-    target_sd->sem_ctime = tswapal(host_sd->sem_ctime);
-    unlock_user_struct(target_sd, target_addr, 1);
-
-    return 0;
+    __put_user(host_sd->sem_nsems, &target_sd->sem_nsems);
+    __put_user(host_sd->sem_otime, &target_sd->sem_otime);
+    __put_user(host_sd->sem_ctime, &target_sd->sem_ctime);
 }
 
-abi_long target_to_host_msqid_ds(struct msqid_ds *host_md,
-        abi_ulong target_addr)
+void target_to_host_msqid_ds(struct msqid_ds *host_md,
+                             struct target_msqid_ds *target_md)
 {
-    struct target_msqid_ds *target_md;
-
-    if (!lock_user_struct(VERIFY_READ, target_md, target_addr, 1)) {
-        return -TARGET_EFAULT;
-    }
-
     memset(host_md, 0, sizeof(struct msqid_ds));
-    target_to_host_ipc_perm__locked(&host_md->msg_perm,
-	&target_md->msg_perm);
-
+    target_to_host_ipc_perm(&host_md->msg_perm, &target_md->msg_perm);
     /* msg_first and msg_last are not used by IPC_SET/IPC_STAT in kernel. */
-    host_md->msg_cbytes = tswapal(target_md->msg_cbytes);
-    host_md->msg_qnum = tswapal(target_md->msg_qnum);
-    host_md->msg_qbytes = tswapal(target_md->msg_qbytes);
-    host_md->msg_lspid = tswapal(target_md->msg_lspid);
-    host_md->msg_lrpid = tswapal(target_md->msg_lrpid);
-#if defined(TARGET_I386)
-    host_md->msg_stime = tswap32(target_md->msg_stime);
-    host_md->msg_rtime = tswap32(target_md->msg_rtime);
-    host_md->msg_ctime = tswap32(target_md->msg_ctime);
-#else
-    host_md->msg_stime = tswap64(target_md->msg_stime);
-    host_md->msg_rtime = tswap64(target_md->msg_rtime);
-    host_md->msg_ctime = tswap64(target_md->msg_ctime);
-#endif
-    unlock_user_struct(target_md, target_addr, 0);
-
-    return 0;
+    __get_user(host_md->msg_cbytes, &target_md->msg_cbytes);
+    __get_user(host_md->msg_qnum,   &target_md->msg_qnum);
+    __get_user(host_md->msg_qbytes, &target_md->msg_qbytes);
+    __get_user(host_md->msg_lspid,  &target_md->msg_lspid);
+    __get_user(host_md->msg_lrpid,  &target_md->msg_lrpid);
+    __get_user(host_md->msg_stime,  &target_md->msg_stime);
+    __get_user(host_md->msg_rtime,  &target_md->msg_rtime);
+    __get_user(host_md->msg_ctime,  &target_md->msg_ctime);
 }
 
-abi_long host_to_target_msqid_ds(abi_ulong target_addr,
-        struct msqid_ds *host_md)
+void host_to_target_msqid_ds(struct target_msqid_ds *target_md,
+                             struct msqid_ds *host_md)
 {
-    struct target_msqid_ds *target_md;
-
-    if (!lock_user_struct(VERIFY_WRITE, target_md, target_addr, 0)) {
-        return -TARGET_EFAULT;
-    }
-
     memset(target_md, 0, sizeof(struct target_msqid_ds));
-    host_to_target_ipc_perm__locked(&target_md->msg_perm,
-	&host_md->msg_perm);
-
+    host_to_target_ipc_perm(&target_md->msg_perm, &host_md->msg_perm);
     /* msg_first and msg_last are not used by IPC_SET/IPC_STAT in kernel. */
-    target_md->msg_cbytes = tswapal(host_md->msg_cbytes);
-    target_md->msg_qnum = tswapal(host_md->msg_qnum);
-    target_md->msg_qbytes = tswapal(host_md->msg_qbytes);
-    target_md->msg_lspid = tswapal(host_md->msg_lspid);
-    target_md->msg_lrpid = tswapal(host_md->msg_lrpid);
-#if defined(TARGET_I386)
-    target_md->msg_stime = tswap32(host_md->msg_stime);
-    target_md->msg_rtime = tswap32(host_md->msg_rtime);
-    target_md->msg_ctime = tswap32(host_md->msg_ctime);
-#else
-    target_md->msg_stime = tswap64(host_md->msg_stime);
-    target_md->msg_rtime = tswap64(host_md->msg_rtime);
-    target_md->msg_ctime = tswap64(host_md->msg_ctime);
-#endif
-    unlock_user_struct(target_md, target_addr, 1);
-
-    return 0;
+    __put_user(host_md->msg_cbytes, &target_md->msg_cbytes);
+    __put_user(host_md->msg_qnum,   &target_md->msg_qnum);
+    __put_user(host_md->msg_qbytes, &target_md->msg_qbytes);
+    __put_user(host_md->msg_lspid,  &target_md->msg_lspid);
+    __put_user(host_md->msg_lrpid,  &target_md->msg_lrpid);
+    __put_user(host_md->msg_stime,  &target_md->msg_stime);
+    __put_user(host_md->msg_rtime,  &target_md->msg_rtime);
+    __put_user(host_md->msg_ctime,  &target_md->msg_ctime);
 }
+
+int semarray_length(int semid) {
+    int err;
+    union semun semun;
+    struct semid_ds semid_ds;
+
+    semun.buf = &semid_ds;
+    err = semctl(semid, 0, IPC_STAT, semun);
+    if (!err) {
+        return semid_ds.sem_nsems;
+    }
+    return -1;
+}
+

--- a/bsd-user/qemu-bsd.h
+++ b/bsd-user/qemu-bsd.h
@@ -72,13 +72,13 @@ abi_long host_to_target_msqid_ds(abi_ulong target_addr,
         struct msqid_ds *host_md);
 
 /* bsd-mem.c */
-void target_to_host_ipc_perm__locked(struct ipc_perm *host_ip,
-        struct target_ipc_perm *target_ip);
-void host_to_target_ipc_perm__locked(struct target_ipc_perm *target_ip,
-        struct ipc_perm *host_ip);
-abi_long target_to_host_shmid_ds(struct shmid_ds *host_sd,
-        abi_ulong target_addr);
-abi_long host_to_target_shmid_ds(abi_ulong target_addr,
-        struct shmid_ds *host_sd);
+void target_to_host_ipc_perm(struct ipc_perm *host_ip,
+                             struct target_ipc_perm *target_ip);
+void host_to_target_ipc_perm(struct target_ipc_perm *target_ip,
+                             struct ipc_perm *host_ip);
+void target_to_host_shmid_ds(struct shmid_ds *host_sd,
+                             struct target_shmid_ds *target_sd);
+void host_to_target_shmid_ds(struct target_shmid_ds *target_sd,
+                             struct shmid_ds *host_sd);
 
 #endif /* QEMU_BSD_H */

--- a/bsd-user/qemu-bsd.h
+++ b/bsd-user/qemu-bsd.h
@@ -54,22 +54,30 @@ abi_long target_to_host_ip_mreq(struct ip_mreqn *mreqn, abi_ulong target_addr,
         socklen_t len);
 
 /* bsd-misc.c */
-abi_long host_to_target_uuid(abi_ulong target_addr, struct uuid *host_uuid);
+int semarray_length(int semid);
 
-abi_long target_to_host_semarray(int semid, unsigned short **host_array,
-        abi_ulong target_addr);
-abi_long host_to_target_semarray(int semid, abi_ulong target_addr,
-        unsigned short **host_array);
+void host_to_target_uuid(struct target_uuid *target_uuid,
+                         struct uuid *host_uuid);
 
-abi_long target_to_host_semid_ds(struct semid_ds *host_sd,
-        abi_ulong target_addr);
-abi_long host_to_target_semid_ds(abi_ulong target_addr,
-        struct semid_ds *host_sd);
+void target_to_host_semarray(unsigned short *host_array,
+                             unsigned short *target_array,
+                             int nsems);
 
-abi_long target_to_host_msqid_ds(struct msqid_ds *host_md,
-        abi_ulong target_addr);
-abi_long host_to_target_msqid_ds(abi_ulong target_addr,
-        struct msqid_ds *host_md);
+void host_to_target_semarray(unsigned short *target_array,
+                             unsigned short *host_array,
+                             int nsems);
+
+void target_to_host_semid_ds(struct semid_ds *host_sd,
+                             struct target_semid_ds *target_sd);
+
+void host_to_target_semid_ds(struct target_semid_ds *target_sd,
+                             struct semid_ds *host_sd);
+
+void target_to_host_msqid_ds(struct msqid_ds *host_md,
+                             struct target_msqid_ds *target_md);
+
+void host_to_target_msqid_ds(struct target_msqid_ds *target_md,
+                             struct msqid_ds *host_md);
 
 /* bsd-mem.c */
 void target_to_host_ipc_perm(struct ipc_perm *host_ip,


### PR DESCRIPTION
# Motivation
This commit suggests an alternative pattern to execute system calls from the guest,
the current pattern can be seen in the following example:

``` C
int host_to_target(abi_ulong target_addr, struct sometype *hptr)
{
    struct taret_sometype *tptr;
    if(!(tptr = lock_user(VERIFY_WRITE, hptr, sizeof(*tptr), 0))) {
        return -TARGET_EFAULT;
    }
    __put_user(...);
    return 0;
}

abi_long do_some_syscall(abi_ulong addr, ...)
{
    struct sometype h;
    abi_long ret;
    ...;
    if(!access_ok(VERIFY_WRITE, addr, sizeof(target_sometype))) {
        return -TARGET_EFAULT;
    }
    ret = some_syscall(&h);
    host_to_target(addr, &h);
    return ret;
}
```
There are several sites where
```C
if(!access_ok(VERIFY_WRITE, addr, sizeof(target_sometype)))
``` 
is replaced with a `lock_user` call.

There is, almost, always two calls to `access_ok`, one for permissions check,
to avoid executing system the system call when the memory is not writable for example, and one for data conversion, to write the data back to the target space.

The alternative is a context macro, used like this
``` C
void host_to_target(struct target_sometype *tptr, struct sometype *hptr)
{
    __put_user(...);
}
abi_long do_some_syscall(abi_ulong addr)
{
    struct sometype h;
    struct target_sometype *tptr;

    WITH_LOCK(tptr, VERIFY_WRITE, addr) {
        if(tptr == NULL) {
            return -TARGET_EFAULT;
        }
        ret = some_syscall(&h);
        host_to_target(tptr, &h);
    }
    return ret;
}
```
# Definition
The initial definition is very simple

``` C
#define WITH_LOCK_VEC(host_ptr, type, guest_addr, len)              \
    for (int brk = 0,                                               \
             copy_in = type == VERIFY_READ,                         \
             copy_out = type == VERIFY_WRITE;                       \
         !brk; )                                                    \
        for (host_ptr = lock_user(type, guest_addr, len, copy_in);  \
             !(brk++);                                              \
             unlock(host_ptr, guest_addr, copy_out ? len : 0))

/* lock/unlock a target struct */
#define WITH_LOCK_STRUCT(host_ptr, type, guest_addr)                \
    WITH_LOCK_VEC(host_ptr, type, guest_addr, sizeof(*host_ptr))

/* This is used to select one of above two macros
 ,* based on the number of params.
 ,*/
#define WITH_LOCK_DISPATCH(_1, _2, _3, _4, NAME, ...) NAME

#define WITH_LOCK(...)                                  \
    WITH_LOCK_DISPATCH(__VA_ARGS__,                     \
                       WITH_LOCK_VEC,                   \
                       WITH_LOCK_STRUCT) (__VA_ARGS__)
```
This allows to dispatch based on the number of args, where **not** supplying
length leads to using the **target_struct** length.

## limitations
The above definition does not handle unlocking well, since it unlocks in the loop-expression,
this, this is not executed on early returns, like
``` C
abi_long do_some_syscall(abi_ulong addr, int cnt)
{
    struct sometype h;
    struct target_sometype *tptr;
    int *array;
    WITH_LOCK(tptr, VERIFY_WRITE, addr) {
        if(tptr == NULL) {
            return -TARGET_EFAULT;
        }
        array = g_try_new(int, cnt);
        if (array == NULL) {
            return -TARGET_ENOMEM;
        }
        ret = some_syscall(&h);
        host_to_target(tptr, &h);
    }
    return ret;
}
```

The first return means that locking failed, so there is no need to unlock, but the second fails due to out-of-memory error, this must unlock the memory before returning.

## Solution
Store loop variables for each parameter

``` C
#define CONCAT(a, b) CONCAT_(a,b)
#define CONCAT_(a, b) a##b

/* lock/unlock a byte vector of length len */
#define WITH_LOCK_VEC(host_ptr, type, guest_addr, len)              \
    for (abi_ulong brk = 0,                                         \
             CONCAT(host_ptr, _gaddr) = guest_addr,                 \
             CONCAT(host_ptr, _len) = len,                          \
             CONCAT(host_ptr, _copy_in) = type == VERIFY_READ,      \
             CONCAT(host_ptr, _copy_out) = type == VERIFY_WRITE;    \
         !brk; )                                                    \
        for (host_ptr = lock_user(type,                             \
                                  CONCAT(host_ptr, _gaddr),         \
                                  CONCAT(host_ptr, _len),           \
                                  CONCAT(host_ptr, _copy_in));      \
             !(brk++);                                              \
             UNLOCK(host_ptr))

#define UNLOCK(host_ptr)                                                \
    unlock_user(host_ptr,                                               \
                CONCAT(host_ptr, _gaddr),                               \
                CONCAT(host_ptr, _copy_out) ? CONCAT(host_ptr, _len) : 0)

/* lock/unlock a target struct */
#define WITH_LOCK_STRUCT(host_ptr, type, guest_addr)                \
    WITH_LOCK_VEC(host_ptr, type, guest_addr, sizeof(*host_ptr))

/* This is used to select one of above two macros
 * based on the number of params.
 */
#define WITH_LOCK_DISPATCH(_1, _2, _3, _4, NAME, ...) NAME

#define WITH_LOCK(...)                                  \
    WITH_LOCK_DISPATCH(__VA_ARGS__,                     \
                       WITH_LOCK_VEC,                   \
                       WITH_LOCK_STRUCT) (__VA_ARGS__)
```

The main idea to notice here is that all `lock_user` parameters are numbers, and since we `unlock` based on the `host_ptr`, we only need to store `guest_addr`, `len` and `type == VERIFY_WRITE`.

since `access_ok` type signature is
``` C
static inline int access_ok(int type, abi_ulong addr, abi_ulong size)
```

We use `abi_ulong` for `_gaddr` and `_len`, `brk`, `copy_in` and `copy_out` are used as bools.

Note: We use host_ptr as a namespacing method, to solve the problem of nested locking,
see for example `do_bsd_msgrcv` in `bsd-misc.h`.

The usage becomes
``` C
abi_long do_some_syscall(abi_ulong addr, int cnt)
{
    struct sometype h;
    struct target_sometype *tptr;
    int *array;
    WITH_LOCK(tptr, VERIFY_WRITE, addr) {
        if(tptr == NULL) {
            return -TARGET_EFAULT;
        }
        array = g_try_new(int, cnt);
        if (array == NULL) {
            UNLOCK(tptr);
            return -TARGET_ENOMEM;
        }
        ret = some_syscall(&h);
        host_to_target(tptr, &h);
    }
    return ret;
}
```

# Conclusion
I believe this makes the locking/unlocking code more coherent, and makes it easier to check for correctness, especially for system calls that write and read
data based on supplied command, like `shmctl` or `semctl`.

It also makes all conversion functions equivalent to several `memcpy`s of different
fields, this avoids locking of nested structures, compare the old definitions
of `host_target_semid_ds` to the new ones.

# Other notes
For all `WITH_LOCK(, VERIFY_WRITE,,)` consider adding `if (ret)` before calling
`host_to_target`, for example see `do_bsd_uuidgen`.

change the type of the formal paramater `len` of `lock_user`, I think it should be
`abi_ulong` as in `access_ok`.


------------------------------------------------------------
This pull request rewrites the definitions in `bsd-mem.c`, `bsd-misc.c`, `bsd-mem.h` and `bsd-misc.h` as a demonstration for `WITH_LOCK` usage.