### PR TITLE
bsd-user: Automatically enable guest_base when guest would overlap host

### DIFF
--- a/bsd-user/bsd-proc.h
+++ b/bsd-user/bsd-proc.h
@@ -26,8 +26,14 @@
 #include "gdbstub/syscalls.h"
 #include "qemu/plugin.h"
 
+struct mapped_range {
+    uintptr_t start;
+    uintptr_t end;
+};
+
 extern int _getlogin(char*, int);
 int bsd_get_ncpu(void);
+struct mapped_range *bsd_get_mapped_ranges(unsigned int *countp);
 
 /* exit(2) */
 static inline abi_long do_bsd_exit(void *cpu_env, abi_long arg1)


### PR DESCRIPTION
I fully expect to have screwed things up here (especially 32-on-64), but it seems to at least pass basic testing for riscv64-on-arm64 via poudriere bulk devel/git.

If you're wondering why bsd_get_mapped_ranges is in its own file, rather than just using libprocstat directly, it's because libprocstat.h pulls in FreeBSD's sys/elf.h, which conflicts with QEMU's own definitions as pulled in by bsd-user/freebsd/target_os_elf.h. bsd-proc.c is a file that doesn't end up including that, and seems a reasonable place to dump the implementation. It also has the benefit of abstracting out the underlying retrieval, should some other implementation be needed on other BSDs.

Scrutiny and testing are to be encouraged by those willing.