### PR TITLE
Signal fixes

### DIFF
--- a/bsd-user/bsd-signal.h
+++ b/bsd-user/bsd-signal.h
@@ -149,6 +149,9 @@ static inline abi_long do_bsd_sigsuspend(void *cpu_env, abi_long arg1,
 /* sigreturn(2) */
 static inline abi_long do_bsd_sigreturn(void *cpu_env, abi_long arg1)
 {
+    if (block_signals()) {
+        return -TARGET_ERESTART;
+    }
     return do_sigreturn(cpu_env, arg1);
 }
 

--- a/bsd-user/freebsd/os-thread.h
+++ b/bsd-user/freebsd/os-thread.h
@@ -169,7 +169,7 @@ static inline abi_long do_freebsd_getcontext(void *cpu_env, abi_ulong arg1)
     if (arg1 == 0) {
         return -TARGET_EINVAL;
     }
-    ret = get_errno(sigprocmask(0, NULL, &sigmask));
+    ret = do_sigprocmask(0, NULL, &sigmask);
     if (!is_error(ret)) {
         ucp = lock_user(VERIFY_WRITE, arg1, sizeof(target_ucontext_t), 0);
         if (ucp == 0) {
@@ -199,7 +199,7 @@ static inline abi_long do_freebsd_setcontext(void *cpu_env, abi_ulong arg1)
     target_to_host_sigset(&sigmask, &ucp->uc_sigmask);
     unlock_user(ucp, arg1, sizeof(target_ucontext_t));
     if (!is_error(ret)) {
-        (void)sigprocmask(SIG_SETMASK, &sigmask, NULL);
+        (void)do_sigprocmask(SIG_SETMASK, &sigmask, NULL);
     }
     return ret == 0 ? -TARGET_EJUSTRETURN : ret;
 }
@@ -216,7 +216,7 @@ static inline abi_long do_freebsd_swapcontext(void *cpu_env, abi_ulong arg1,
         return -TARGET_EINVAL;
     }
     /* Save current context in arg1. */
-    ret = get_errno(sigprocmask(0, NULL,  &sigmask));
+    ret = do_sigprocmask(0, NULL, &sigmask);
     if (!is_error(ret)) {
         ucp = lock_user(VERIFY_WRITE, arg1, sizeof(target_ucontext_t), 0);
         if (ucp == 0) {
@@ -240,7 +240,7 @@ static inline abi_long do_freebsd_swapcontext(void *cpu_env, abi_ulong arg1,
     target_to_host_sigset(&sigmask, &ucp->uc_sigmask);
     unlock_user(ucp, arg2, sizeof(target_ucontext_t));
     if (!is_error(ret)) {
-        (void)sigprocmask(SIG_SETMASK, &sigmask, NULL);
+        (void)do_sigprocmask(SIG_SETMASK, &sigmask, NULL);
     }
     return ret == 0 ? -TARGET_EJUSTRETURN : ret;
 }

--- a/bsd-user/signal-common.h
+++ b/bsd-user/signal-common.h
@@ -32,6 +32,7 @@ int block_signals(void); /* Returns non zero if signal pending */
 long do_rt_sigreturn(CPUArchState *env);
 int do_sigaction(int sig, const struct target_sigaction *act,
                 struct target_sigaction *oact);
+int do_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
 abi_long do_sigaltstack(abi_ulong uss_addr, abi_ulong uoss_addr, abi_ulong sp);
 long do_sigreturn(CPUArchState *env, abi_ulong addr);
 void force_sig_fault(int sig, int code, abi_ulong addr);

--- a/bsd-user/signal.c
+++ b/bsd-user/signal.c
@@ -747,6 +747,46 @@ int do_sigaction(int sig, const struct target_sigaction *act,
     return ret;
 }
 
+int do_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
+{
+    TaskState *ts = get_task_state(thread_cpu);
+
+    if (oldset) {
+        *oldset = ts->signal_mask;
+    }
+
+    if (set) {
+        int i;
+
+        if (block_signals()) {
+            return -TARGET_ERESTART;
+        }
+
+        switch (how) {
+        case SIG_BLOCK:
+            sigorset(&ts->signal_mask, &ts->signal_mask, set);
+            break;
+        case SIG_UNBLOCK:
+            for (i = 1; i <= NSIG; ++i) {
+                if (sigismember(set, i)) {
+                    sigdelset(&ts->signal_mask, i);
+                }
+            }
+            break;
+        case SIG_SETMASK:
+            ts->signal_mask = *set;
+            break;
+        default:
+            g_assert_not_reached();
+        }
+
+        /* Silently ignore attempts to change blocking status of KILL or STOP */
+        sigdelset(&ts->signal_mask, SIGKILL);
+        sigdelset(&ts->signal_mask, SIGSTOP);
+    }
+    return 0;
+}
+
 static inline abi_ulong get_sigframe(struct target_sigaction *ka,
         CPUArchState *env, size_t frame_size)
 {
@@ -979,7 +1019,6 @@ static void handle_pending_signal(CPUArchState *env, int sig,
             &ts->sigsuspend_mask : &ts->signal_mask;
         sigorset(&ts->signal_mask, blocked_set, &set);
         ts->in_sigsuspend = false;
-        sigprocmask(SIG_SETMASK, &ts->signal_mask, NULL);
 
 #if 0  /* not yet */
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)

--- a/bsd-user/signal.c
+++ b/bsd-user/signal.c
@@ -1093,6 +1093,12 @@ void process_pending_signals(CPUArchState *env)
         /*
          * Unblock signals and check one more time. Unblocking signals may cause
          * us to take another host signal, which will set signal_pending again.
+         *
+         * XXX: This is what linux-user does, but should this not use the old
+         * mask from the original sigprocmask above instead? This only works
+         * because, when we get the sigreturn, we come back here again, but
+         * until then for a non-SA_NODEFER handler we'll have any pending
+         * signals masked out for the host.
          */
         qatomic_set(&ts->signal_pending, 0);
         ts->in_sigsuspend = false;


### PR DESCRIPTION
I discovered there was a problem here by accident, since poudriere thought it didn't need to emulate armv7 on my Mac and thus didn't build native xtools for the jail, which meant bmake was being emulated and got stuck. Using native xtools lets one mostly ignore the problem, but this gave an easy reproducer of something for which we don't know the scope of the problem.

```
bsd-user: Don't manipulate host signal mask for sigprocmask

We would previously both manipulate TaskState's signal_mask and also
reflect that by using the host's sigprocmask, but QEMU expects to have
full control over the host signals (for example, this would stop SIGSEGV
from being able to core dump). Instead, only touch the TaskState's
signal_mask.

This restructuring also mirrors the linux-user code rather than mixing
in the translation and emulation steps. Aside from thr_new, signal.c is
now the only file to be touching signal_mask.

This also fixes SIG_UNBLOCK emulation, which was passing the updated
signal_mask to sigprocmask with SIG_UNBLOCK, which would not in fact
unblock the signal. This also fixes the wrong error being returned for a
bad "how".
```
```
bsd-user: Block signals during sigreturn

This matches linux-user, and is needed to ensure we get the right
signal mask after a sigreturn. I'm not convinced passing ts->signal_mask
to sigprocmask inside process_pending_signals is correct, but it's what
linux-user does, and this is how linux-user ends up working rather than
leaving the previous set of taken signals blocked for the host, thereby
preventing back-to-back signals from being delivered.

In particular, this case fixes running bmake as an emulated process, as
it was previously getting stuck with SIGCHLD blocked for the host.
```