### PR TITLE
bsd-user: replacing number with register constants

### DIFF
--- a/BSD-USER.rst
+++ b/BSD-USER.rst
@@ -129,9 +129,10 @@ Building Test Binaries Without The Jail
 Since you've created the jail, you have a 'sysroot' that you can use to build
 binaries. Let's say you want to build hello-armv7 from hello.c.
 
-.. codeblock:: shell
+.. code-block:: shell
 
-% cc -target freebsd-armv7 --sysroot /vidpool/qemu/jails/jails/131armv7 -o hello-armv7
+ % cc -target freebsd-armv7 --sysroot /vidpool/qemu/jails/jails/131armv7 -o hello-armv7
+
 
 Will do the trick.
 
@@ -143,12 +144,12 @@ will still need to create the jail, as outlined above, but you don't need to
 start it. You'll need to get the 'root' of the jail for this step. Use
 `poudriere jail -l` to get a list of all your jails, and to find the root
 
-.. codeblock:: shell
+.. code-block:: shell
 
-# joudriere jail -l
-JAILNAME        VERSION                              ARCH      METHOD  TIMESTAMP           PATH
-131armv7        13.2-RC3 1302001 d9bf9d732           arm.armv7 git+ssh 2023-03-18 13:54:23 /vidpool/qemu/jails/jails/131armv7
-#
+ # joudriere jail -l
+ JAILNAME        VERSION                              ARCH      METHOD  TIMESTAMP           PATH
+ 131armv7        13.2-RC3 1302001 d9bf9d732           arm.armv7 git+ssh 2023-03-18 13:54:23 /vidpool/qemu/jails/jails/131armv7
+ #
 
 In this case, it's the PATH column.
 
@@ -157,11 +158,11 @@ directly to do this test. Let's say you have a 'hello world' binary that you're
 trying to debug. For example, if you're debugging an arm binary using the above
 jail:
 
-.. codeblock:: shell
+.. code-block:: shell
 
-% cd qemu/00-qemu
-% <build-here>
-% qemu-arm -L /vidpool/qemu/jails/jails/131armv7 hello-arm
+ % cd qemu/00-qemu
+ % <build-here>
+ % qemu-arm -L /vidpool/qemu/jails/jails/131armv7 hello-arm
 
 whill run it looking in the jail's root directory for all the dynamic parts of
 the binary (ld-elf.so, libc.so, etc).

--- a/bsd-user/riscv/signal.c
+++ b/bsd-user/riscv/signal.c
@@ -38,14 +38,14 @@ set_sigtramp_args(CPURISCVState *regs, int sig, struct target_sigframe *frame,
      *  ra (1)  = sigtramp at base of user stack
      */
 
-     regs->gpr[10] = sig;
-     regs->gpr[11] = frame_addr +
+     regs->gpr[xA0] = sig;
+     regs->gpr[xA1] = frame_addr +
          offsetof(struct target_sigframe, sf_si);
-     regs->gpr[12] = frame_addr +
+     regs->gpr[xA2] = frame_addr +
          offsetof(struct target_sigframe, sf_uc);
      regs->pc = ka->_sa_handler;
-     regs->gpr[2] = frame_addr;
-     regs->gpr[1] = TARGET_PS_STRINGS - TARGET_SZSIGCODE;
+     regs->gpr[xSP] = frame_addr;
+     regs->gpr[xRA] = TARGET_PS_STRINGS - TARGET_SZSIGCODE;
      return 0;
 }
 

--- a/bsd-user/riscv/target_arch_cpu.h
+++ b/bsd-user/riscv/target_arch_cpu.h
@@ -137,7 +137,7 @@ static inline void target_cpu_clone_regs(CPURISCVState *env, target_ulong newsp)
     }
 
     env->gpr[xA0] = 0; /* a0 */
-    env->gpr[xT0] = 0;   /* t0 */
+    env->gpr[xT0] = 0; /* t0 */
 }
 
 static inline void target_cpu_reset(CPUArchState *env)

--- a/bsd-user/riscv/target_arch_cpu.h
+++ b/bsd-user/riscv/target_arch_cpu.h
@@ -29,7 +29,7 @@ static inline void target_cpu_init(CPURISCVState *env,
 {
     int i;
 
-    for (i = 0; i < 32; i++) {
+    for (i = 1; i < 32; i++) {
         env->gpr[i] = regs->regs[i];
     }
 

--- a/bsd-user/riscv/target_arch_cpu.h
+++ b/bsd-user/riscv/target_arch_cpu.h
@@ -137,7 +137,7 @@ static inline void target_cpu_clone_regs(CPURISCVState *env, target_ulong newsp)
     }
 
     env->gpr[xA0] = 0; /* a0 */
-    env->gpr[5] = 0;   /* t0 */
+    env->gpr[xT0] = 0;   /* t0 */
 }
 
 static inline void target_cpu_reset(CPUArchState *env)

--- a/bsd-user/riscv/target_arch_sigtramp.h
+++ b/bsd-user/riscv/target_arch_sigtramp.h
@@ -27,7 +27,7 @@ static inline abi_long setup_sigtramp(abi_ulong offset, unsigned sigf_uc,
     int i;
     uint32_t sys_exit = TARGET_FREEBSD_NR_exit;
 
-     static const uint32_t sigtramp_code[] = {
+    static const uint32_t sigtramp_code[] = {
     /* 1 */ const_le32(0x00010513),                         /* mv a0, sp */
     /* 2 */ const_le32(0x00050513 + (sigf_uc << 20)),       /* addi a0, a0, sigf_uc */
     /* 3 */ const_le32(0x00000293 + (sys_sigreturn << 20)), /* li t0, sys_sigreturn */

--- a/bsd-user/riscv/target_arch_sigtramp.h
+++ b/bsd-user/riscv/target_arch_sigtramp.h
@@ -27,19 +27,15 @@ static inline abi_long setup_sigtramp(abi_ulong offset, unsigned sigf_uc,
     int i;
     uint32_t sys_exit = TARGET_FREEBSD_NR_exit;
 
-    uint32_t sigtramp_code[] = {
-    /* 1 */ 0x00010513,                         /* mv a0, sp */
-    /* 2 */ 0x00050513 + (sigf_uc << 20),       /* addi a0, a0, sigf_uc */
-    /* 3 */ 0x00000293 + (sys_sigreturn << 20), /* li t0, sys_sigreturn */
-    /* 4 */ 0x00000073,                         /* ecall */
-    /* 5 */ 0x00000293 + (sys_exit << 20),      /* li t0, sys_exit */
-    /* 6 */ 0x00000073,                         /* ecall */
-    /* 7 */ 0xFF1FF06F                          /* b -16 */
+     static const uint32_t sigtramp_code[] = {
+    /* 1 */ const_le32(0x00010513),                         /* mv a0, sp */
+    /* 2 */ const_le32(0x00050513 + (sigf_uc << 20)),       /* addi a0, a0, sigf_uc */
+    /* 3 */ const_le32(0x00000293 + (sys_sigreturn << 20)), /* li t0, sys_sigreturn */
+    /* 4 */ const_le32(0x00000073),                         /* ecall */
+    /* 5 */ const_le32(0x00000293 + (sys_exit << 20)),      /* li t0, sys_exit */
+    /* 6 */ const_le32(0x00000073),                         /* ecall */
+    /* 7 */ const_le32(0xFF1FF06F)                          /* b -16 */
     };
-
-    for (i = 0; i < 7; i++) {
-        tswap32s(&sigtramp_code[i]);
-    }
 
     return memcpy_to_target(offset, sigtramp_code, TARGET_SZSIGCODE);
 }

--- a/bsd-user/riscv/target_arch_thread.h
+++ b/bsd-user/riscv/target_arch_thread.h
@@ -27,7 +27,7 @@ static inline void target_thread_set_upcall(CPURISCVState *regs,
 {
     abi_ulong sp;
 
-    sp = (abi_ulong)(stack_base + stack_size) & ~(16 - 1);
+    sp = ROUND_DOWN(stack_base + stack_size,16);
 
     regs->gpr[xSP] = sp;
     regs->pc = entry;

--- a/bsd-user/riscv/target_arch_thread.h
+++ b/bsd-user/riscv/target_arch_thread.h
@@ -40,8 +40,8 @@ static inline void target_thread_init(struct target_pt_regs *regs,
 {
     regs->sepc = infop->entry;
     regs->regs[xRA] = infop->entry;
-    regs->regs[10] = infop->start_stack;               /* a0 */
-    regs->regs[xSP] = infop->start_stack & ~(16 - 1);
+    regs->regs[xA0] = infop->start_stack;               /* a0 */
+    regs->regs[xSP] = ROUND_DOWN(infop->start_stack,16);
 }
 
 #endif /* TARGET_ARCH_THREAD_H */


### PR DESCRIPTION
In some files array subscript  were replace by the register constants such as xA0,XA1,etc.
Also ROUND_DOWN was used to align the stack