### PR TITLE
Fix running huge non-PIE dynamic binaries by static qemu

### DIFF
--- a/bsd-user/elfload.c
+++ b/bsd-user/elfload.c
@@ -560,12 +560,14 @@ load_elf_sections(const struct elfhdr *hdr, struct elf_phdr *phdr, int fd,
             elf_prot |= PROT_EXEC;
         }
 
+        int flags = MAP_FIXED | MAP_PRIVATE | MAP_DENYWRITE;
+        if (rbase == 0) {
+            flags |= MAP_EXCL;
+        }
         error = target_mmap(TARGET_ELF_PAGESTART(rbase + elf_ppnt->p_vaddr),
                             (elf_ppnt->p_filesz +
                              TARGET_ELF_PAGEOFFSET(elf_ppnt->p_vaddr)),
-                            elf_prot,
-                            (MAP_FIXED | MAP_PRIVATE | MAP_DENYWRITE),
-                            fd,
+                            elf_prot, flags, fd,
                             (elf_ppnt->p_offset -
                              TARGET_ELF_PAGEOFFSET(elf_ppnt->p_vaddr)));
         if (error == -1) {


### PR DESCRIPTION
This patch improves loading of the non-PIE binaries by properly requesting MAP_EXCL when doing mmap for the binary text. The problem with non-PIE binaries is that they need to be loaded at the very specific address, so that if guest_base is not set that is going to be the same address where qemu itself resides if linked statically. As such, after mmap() it would return to the PROT_READ page and crash immediately in the libc code. So if this situation happens we propagate the error and failed address all the way up to the main(), find the unused area and bump the guest_base accordingly.