### PR TITLE
Fix x86 64 upcall() and set_tls()

### DIFF
--- a/bsd-user/x86_64/target_arch.h
+++ b/bsd-user/x86_64/target_arch.h
@@ -26,6 +26,11 @@ void bsd_x86_64_write_dt(void *ptr, unsigned long addr, unsigned long limit,
 void bsd_x86_64_set_idt(int n, unsigned int dpl);
 void bsd_x86_64_set_idt_base(uint64_t base);
 
-#define target_cpu_set_tls(env, newtls)
+static inline void
+target_cpu_set_tls(CPUX86State *env, target_ulong newtls)
+{
+    env->segs[R_FS].base = newtls;
+}
+
 
 #endif /* TARGET_ARCH_H */

--- a/bsd-user/x86_64/target_arch_thread.h
+++ b/bsd-user/x86_64/target_arch_thread.h
@@ -21,10 +21,13 @@
 #define TARGET_ARCH_THREAD_H
 
 /* Compare to vm_machdep.c cpu_set_upcall_kse() */
-static inline void target_thread_set_upcall(CPUX86State *regs, abi_ulong entry,
+static inline void target_thread_set_upcall(CPUX86State *env, abi_ulong entry,
     abi_ulong arg, abi_ulong stack_base, abi_ulong stack_size)
 {
-    /* XXX */
+    env->regs[R_EBP] = 0;
+    env->regs[R_ESP] = ((stack_base + stack_size) & ~0x0f) - 8;
+    env->eip = entry;
+    env->regs[R_EDI] = arg;
 }
 
 static inline void target_thread_init(struct target_pt_regs *regs,


### PR DESCRIPTION
Those two routines are important for the thr_new() syscall to work properly. Neither was implemented for x86_64 (supposedly just because nobody wants to emulate x86_64 yet?), so this PR adds those missing pieces. Tested with both FreeBSD emulation on FreeBSD and FreeBSD emulation on Linux.