### PR TITLE
Fix dynamic linking

### DIFF
--- a/bsd-user/freebsd/os-file.h
+++ b/bsd-user/freebsd/os-file.h
@@ -23,7 +23,7 @@
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1300133
 #include <sys/specialfd.h>
 
-int __sys___specialfd(int, const void *, size_t);
+#define fast___specialfd(a1, a2, a3) syscall(SYS___specialfd, (a1), (a2), (a3))
 #endif
 
 /*
@@ -134,7 +134,7 @@ static inline abi_long do_freebsd___specialfd(int type, abi_ulong req,
 
         evfd.initval = tswap32(target_eventfd->initval);
         evfd.flags = tswap32(target_eventfd->flags);
-        ret = get_errno(__sys___specialfd(type, &evfd, sizeof(evfd)));
+        ret = get_errno(fast___specialfd(type, &evfd, sizeof(evfd)));
         unlock_user_struct(target_eventfd, req, 0);
         break;
     }

--- a/bsd-user/freebsd/os-stat.h
+++ b/bsd-user/freebsd/os-stat.h
@@ -635,8 +635,9 @@ static inline abi_long do_freebsd_fcntl(abi_long arg1, abi_long arg2,
 }
 
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1300080
-extern int __realpathat(int fd, const char *path, char *buf, size_t size,
-        int flags);
+#define fast___realpathat(a1, a2, a3, a4, a5) \
+          syscall(SYS___realpathat, (a1), (a2), (a3), (a4), (a5))
+
 /* https://svnweb.freebsd.org/base?view=revision&revision=358172 */
 /* no man page */
 static inline abi_long do_freebsd_realpathat(abi_long arg1, abi_long arg2,
@@ -652,7 +653,7 @@ static inline abi_long do_freebsd_realpathat(abi_long arg1, abi_long arg2,
         return -TARGET_EFAULT;
     }
 
-    ret = get_errno(__realpathat(arg1, p, b, arg4, arg5));
+    ret = get_errno(fast___realpathat(arg1, p, b, arg4, arg5));
     UNLOCK_PATH(p, arg2);
     unlock_user(b, arg3, ret);
 


### PR DESCRIPTION
ld: error: undefined symbol: __realpathat
>>> referenced by os-stat.h:655 (../bsd-user/freebsd/os-stat.h:655)
>>>               qemu-x86_64.lto.o:(do_freebsd_realpathat)

ld: error: undefined symbol: __sys___specialfd
>>> referenced by os-file.h:137 (../bsd-user/freebsd/os-file.h:137)
>>>               qemu-x86_64.lto.o:(do_freebsd___specialfd)
clang: error: linker command failed with exit code 1 (use -v to see invocation) ninja: build stopped: subcommand failed.

The problem is that dynamic libc does not export wrappers for the __realpathat() and __specialfd(), instead we could just issue those syscalls directly, just like we do for any other syscall.