### PR TITLE
bsd-user: freebsd: fix getdents(2)

### DIFF
--- a/bsd-user/freebsd/os-stat.h
+++ b/bsd-user/freebsd/os-stat.h
@@ -523,6 +523,7 @@ static inline abi_long do_freebsd11_getdents(abi_long arg1,
             de->d_reclen = tswap16(reclen);
             de->d_fileno = tswap32(de->d_fileno);
             len -= reclen;
+            de = (struct freebsd11_dirent *)((void *)de + reclen);
         }
     }
     return ret;


### PR DESCRIPTION
Syscall `getdents` has been historically mistaken the pointer in loops.
Though not used by recent(`__FreeBSD_version >= 1200000`) base libc, this syscall is used by concurrent v4.0.2 [cosmopolitan](https://github.com/jart/cosmopolitan) resulting things like python in [superconfigure](https://github.com/ahgamut/superconfigure) broken.
This patch can also be cherry-picked to branch `blitz`.