### PR TITLE
fix realpathat on FreeBSD main

### DIFF
--- a/bsd-user/freebsd/os-stat.h
+++ b/bsd-user/freebsd/os-stat.h
@@ -685,8 +685,8 @@ static inline abi_long do_freebsd_fcntl(abi_long arg1, abi_long arg2,
 }
 
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1300080
-extern int __realpathat(int fd, const char *path, char *buf, size_t size,
-        int flags);
+extern int __sys___realpathat(int fd, const char * path, char * buf,
+        size_t size, int flags);
 // https://svnweb.freebsd.org/base?view=revision&revision=358172
 // no man page
 static inline abi_long do_freebsd_realpathat(abi_long arg1, abi_long arg2,
@@ -702,7 +702,7 @@ static inline abi_long do_freebsd_realpathat(abi_long arg1, abi_long arg2,
         return -TARGET_EFAULT;
     }
 
-    ret = get_errno(__realpathat(arg1, p, b, arg4, arg5));
+    ret = get_errno(__sys___realpathat(arg1, p, b, arg4, arg5));
     UNLOCK_PATH(p, arg2);
     unlock_user(b, arg3, ret);
 


### PR DESCRIPTION
Call __sys___realpathat() rather than the now removed __realpathat(). Neither are public interfaces, but __sys___realpathat is somewhat more so.