### PR TITLE
freebsd/os-ioctl-cmds.h: remove SIOCSVH

### DIFF
--- a/bsd-user/freebsd/os-ioctl-cmds.h
+++ b/bsd-user/freebsd/os-ioctl-cmds.h
@@ -126,9 +126,6 @@ IOCTL(GREGOPTS, IOC_W | IOC_R, MK_PTR(MK_STRUCT(STRUCT_ifreq_ptr)))
 /* net/if_gif.h */
 IOCTL(GIFGOPTS, IOC_W | IOC_R, MK_PTR(MK_STRUCT(STRUCT_ifreq_ptr)))
 
-/* netinet/ip_carp.h */
-IOCTL(SIOCGVH, IOC_W | IOC_R, MK_PTR(MK_STRUCT(STRUCT_ifreq_ptr)))
-
 /* net/if_pfsync.h */
 #ifdef SIOCGETPFSYNC
 IOCTL(SIOCGETPFSYNC, IOC_W | IOC_R, MK_PTR(MK_STRUCT(STRUCT_ifreq_ptr)))


### PR DESCRIPTION
Needed after https://cgit.freebsd.org/src/commit/?id=72472e52e310ec348949a3a67d3fa17e33fb8e50